### PR TITLE
fix: prevent truncated output

### DIFF
--- a/pmd
+++ b/pmd
@@ -8,11 +8,12 @@ const className = "net.sourceforge.pmd.PMD";
 const args = process.argv.splice(2);
 
 const result = jre.spawnSync(classPath, className, args, {
-  encoding: "utf8"
+  encoding: "utf8",
+  stdio: [
+    "inherit",
+    "inherit",
+    process.env.NPM_PMD_BIN_STDERR === "true" ? "inherit" : "ignore"
+  ]
 });
 
-if (process.env.NPM_PMD_BIN_STDERR === "true") {
-  console.error(result.stderr.trim());
-}
-console.log(result.stdout.trim());
-process.exit(result.status);
+process.exitCode = result.status;


### PR DESCRIPTION
- don't use process.exit according to https://nodejs.org/api/process.html#process_process_exit_code
- leverage stdio of spawn https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options